### PR TITLE
ASA-4900: Honor IRX_MINOR_CACHE_HOME flag in the plugins

### DIFF
--- a/src/main/java/com/hcl/appscan/sdk/scanners/sast/targets/JEETarget.java
+++ b/src/main/java/com/hcl/appscan/sdk/scanners/sast/targets/JEETarget.java
@@ -6,15 +6,25 @@
 
 package com.hcl.appscan.sdk.scanners.sast.targets;
 
+import java.io.File;
 import java.util.Map;
 
 import com.hcl.appscan.sdk.scanners.sast.xml.IModelXMLConstants;
+import com.hcl.appscan.sdk.utils.SystemUtil;
 
 public abstract class JEETarget extends JavaTarget implements IJEETarget {
 
 	@Override
 	public Map<String, String> getProperties() {
 		Map<String, String> buildInfos = super.getProperties();
+		String irx_cache_path = SystemUtil.getIrxMinorCacheHome();
+		
+		if (irx_cache_path != "") {
+			File cache_dir = new File(irx_cache_path);
+			cache_dir.mkdir();
+			buildInfos.put(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME, irx_cache_path);
+		}
+		
 		buildInfos.put(IModelXMLConstants.A_JSP_COMPILER, getJSPCompiler());
 		return buildInfos;
 	}

--- a/src/main/java/com/hcl/appscan/sdk/scanners/sast/targets/JEETarget.java
+++ b/src/main/java/com/hcl/appscan/sdk/scanners/sast/targets/JEETarget.java
@@ -6,25 +6,15 @@
 
 package com.hcl.appscan.sdk.scanners.sast.targets;
 
-import java.io.File;
 import java.util.Map;
 
 import com.hcl.appscan.sdk.scanners.sast.xml.IModelXMLConstants;
-import com.hcl.appscan.sdk.utils.SystemUtil;
 
 public abstract class JEETarget extends JavaTarget implements IJEETarget {
 
 	@Override
 	public Map<String, String> getProperties() {
 		Map<String, String> buildInfos = super.getProperties();
-		String irx_cache_path = SystemUtil.getIrxMinorCacheHome();
-		
-		if (irx_cache_path != "") {
-			File cache_dir = new File(irx_cache_path);
-			cache_dir.mkdir();
-			buildInfos.put(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME, irx_cache_path);
-		}
-		
 		buildInfos.put(IModelXMLConstants.A_JSP_COMPILER, getJSPCompiler());
 		return buildInfos;
 	}

--- a/src/main/java/com/hcl/appscan/sdk/scanners/sast/targets/JavaTarget.java
+++ b/src/main/java/com/hcl/appscan/sdk/scanners/sast/targets/JavaTarget.java
@@ -6,16 +6,26 @@
 
 package com.hcl.appscan.sdk.scanners.sast.targets;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.hcl.appscan.sdk.scanners.sast.xml.IModelXMLConstants;
+import com.hcl.appscan.sdk.utils.SystemUtil;
 
 public abstract class JavaTarget extends DefaultTarget implements IJavaTarget {
 
 	@Override
 	public Map<String, String> getProperties() {
 		HashMap<String, String> buildInfos = new HashMap<String, String>();
+		String irx_cache_path = SystemUtil.getIrxMinorCacheHome();
+		
+		if (irx_cache_path != "") {
+			File cache_dir = new File(irx_cache_path);
+			cache_dir.mkdir();
+			buildInfos.put(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME, irx_cache_path);
+		}
+		
 		buildInfos.put(IModelXMLConstants.A_ADDITIONAL_CLASSPATH, getClasspath());
 		buildInfos.put(IModelXMLConstants.A_JDK_PATH, getJava());
 		return buildInfos;

--- a/src/main/java/com/hcl/appscan/sdk/scanners/sast/targets/JavaTarget.java
+++ b/src/main/java/com/hcl/appscan/sdk/scanners/sast/targets/JavaTarget.java
@@ -20,7 +20,7 @@ public abstract class JavaTarget extends DefaultTarget implements IJavaTarget {
 		HashMap<String, String> buildInfos = new HashMap<String, String>();
 		String irx_cache_path = SystemUtil.getIrxMinorCacheHome();
 		
-		if (irx_cache_path != "") {
+		if (irx_cache_path != null) {
 			File cache_dir = new File(irx_cache_path);
 			cache_dir.mkdir();
 			buildInfos.put(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME, irx_cache_path);

--- a/src/main/java/com/hcl/appscan/sdk/scanners/sast/xml/IModelXMLConstants.java
+++ b/src/main/java/com/hcl/appscan/sdk/scanners/sast/xml/IModelXMLConstants.java
@@ -32,6 +32,7 @@ public interface IModelXMLConstants {
 	String A_JDK_PATH				= "jdk_path";				//$NON-NLS-1$
 	String A_JSP_COMPILER			= "jsp_compiler";			//$NON-NLS-1$
 	String A_ADDITIONAL_CLASSPATH	= "additional_classpath";	//$NON-NLS-1$
+	String A_IRX_MINOR_CACHE_HOME	= "irx_minor_cache_home";	//$NON-NLS-1$
 	String A_OUTPUTS_ONLY			= "outputs-only";			//$NON-NLS-1$
 	
 	//C++

--- a/src/main/java/com/hcl/appscan/sdk/utils/SystemUtil.java
+++ b/src/main/java/com/hcl/appscan/sdk/utils/SystemUtil.java
@@ -145,9 +145,6 @@ public class SystemUtil {
 	 * @return A string representation of the user-specified irx cache location
 	 */
 	public static String getIrxMinorCacheHome() {
-		String irx_cache_path = "";
-		if (System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME.toUpperCase()) != null)
-			irx_cache_path = System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME.toUpperCase());
-		return irx_cache_path;
+		return System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME.toUpperCase());
 	}
 }

--- a/src/main/java/com/hcl/appscan/sdk/utils/SystemUtil.java
+++ b/src/main/java/com/hcl/appscan/sdk/utils/SystemUtil.java
@@ -148,8 +148,6 @@ public class SystemUtil {
 		String irx_cache_path = "";
 		if (System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME.toUpperCase()) != null)
 			irx_cache_path = System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME.toUpperCase());
-		else if (System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME) != null)
-			irx_cache_path = System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME);
 		return irx_cache_path;
 	}
 }

--- a/src/main/java/com/hcl/appscan/sdk/utils/SystemUtil.java
+++ b/src/main/java/com/hcl/appscan/sdk/utils/SystemUtil.java
@@ -7,6 +7,7 @@
 package com.hcl.appscan.sdk.utils;
 
 import com.hcl.appscan.sdk.CoreConstants;
+import com.hcl.appscan.sdk.scanners.sast.xml.IModelXMLConstants;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -136,5 +137,19 @@ public class SystemUtil {
 	 */
 	public static boolean isSourceCodeOnly() {
 		return System.getProperty(CoreConstants.SOURCE_CODE_ONLY) != null;
+	}
+	
+	/**
+	 * Get the IRX cache location from IRX_MINOR_CACHE_HOME flag
+	 *
+	 * @return A string representation of the user-specified irx cache location
+	 */
+	public static String getIrxMinorCacheHome() {
+		String irx_cache_path = "";
+		if (System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME.toUpperCase()) != null)
+			irx_cache_path = System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME.toUpperCase());
+		else if (System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME) != null)
+			irx_cache_path = System.getProperty(IModelXMLConstants.A_IRX_MINOR_CACHE_HOME);
+		return irx_cache_path;
 	}
 }


### PR DESCRIPTION
Fix for IRX_MINOR_CACHE_HOME not being honored for the plugins. This flag is now set in the appscan-config.xml during every scan (if specified) and will be used by CLI to determine the user-specified irx cache location.