### PR TITLE
Removed the unnecessary checks (#103)

### DIFF
--- a/src/main/java/com/hcl/appscan/sdk/scanners/sast/SAClient.java
+++ b/src/main/java/com/hcl/appscan/sdk/scanners/sast/SAClient.java
@@ -110,9 +110,6 @@ public class SAClient implements SASTConstants {
 		m_progress.setStatus(new Message(Message.INFO, Messages.getMessage(PREPARING_IRX, getLocalClientVersion())));
         if((serverURL !=null) && !serverURL.isEmpty()){
             String options = System.getenv(CoreConstants.APPSCAN_OPTS) == null ? "" : System.getenv(CoreConstants.APPSCAN_OPTS);
-            if(!options.contains(CoreConstants.BLUEMIX_SERVER)) {
-                options += " -DBLUEMIX_SERVER=" + serverURL;
-            }
             if("true".equals(acceptInvalidCerts)) {
                 options += " -Dacceptssl";
             }

--- a/src/main/java/com/hcl/appscan/sdk/utils/ServiceUtil.java
+++ b/src/main/java/com/hcl/appscan/sdk/utils/ServiceUtil.java
@@ -69,10 +69,8 @@ public class ServiceUtil implements CoreConstants {
     private static String requiredServerURL(String serverURL){
         String request_url = SystemUtil.getDefaultServer();
         if(serverURL != null && !serverURL.isEmpty()) {
-            if(System.getenv(CoreConstants.APPSCAN_OPTS) == null || !System.getenv(CoreConstants.APPSCAN_OPTS).contains(CoreConstants.BLUEMIX_SERVER)){
                 request_url = serverURL;
             }
-        }
         return request_url;
     }
 	


### PR DESCRIPTION
The customer who needs to connect to a specific server should provide the credentials correctly and Jenkins will not address the bluemix server set in that APPSCAN_OPTS anymore. We have tested it with 360 and working fine. For stage and mirror the server.apsettings file value parameter has to be updated to the corresponding server.