### PR TITLE
PRB fix

### DIFF
--- a/src/main/java/com/hcl/appscan/sdk/results/CloudCombinedResultsProvider.java
+++ b/src/main/java/com/hcl/appscan/sdk/results/CloudCombinedResultsProvider.java
@@ -27,7 +27,7 @@ public class CloudCombinedResultsProvider implements IResultsProvider, Serializa
 	
 	@Override
 	public boolean hasResults() {
-		return m_resultsProvider1.hasResults() || m_resultsProvider2.hasResults();
+		return m_resultsProvider1.hasResults() && m_resultsProvider2.hasResults();
 	}
 
 	@Override


### PR DESCRIPTION
This Change has been made to address an PRB issue: Jenkins Job Report shows no Scan Issues in report when suspend option is disabled.